### PR TITLE
Additional check for compatibility with NativeScript

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var UUID = (function () {
         // no-op
     }
     UUID.UUID = function () {
-        if (typeof (window.crypto) !== "undefined" && typeof (window.crypto.getRandomValues) !== "undefined") {
+        if (typeof (window) !== "undefined" && typeof (window.crypto) !== "undefined" && typeof (window.crypto.getRandomValues) !== "undefined") {
             // If we have a cryptographically secure PRNG, use that
             // http://stackoverflow.com/questions/6906916/collisions-when-generating-uuids-in-javascript
             var buf = new Uint16Array(8);

--- a/index.ts
+++ b/index.ts
@@ -7,7 +7,7 @@ export class UUID {
     }
 
     public static UUID(): string {
-        if (typeof (window.crypto) !== "undefined" && typeof (window.crypto.getRandomValues) !== "undefined") {
+        if (typeof (window) !== "undefined" && typeof (window.crypto) !== "undefined" && typeof (window.crypto.getRandomValues) !== "undefined") {
             // If we have a cryptographically secure PRNG, use that
             // http://stackoverflow.com/questions/6906916/collisions-when-generating-uuids-in-javascript
             let buf: Uint16Array = new Uint16Array(8);


### PR DESCRIPTION
When working in NativeScript environment ‘window’ object is not
available and the check for ‘window.crypto’ fails with exception.

Adding a check for ‘window’ allows to detect it and fallback to Math,
which works fine.